### PR TITLE
Add .gitignore for event-driven CloudFormation project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,70 @@
+# AWS CloudFormation
+.aws-sam/
+.sam/
+packaged-template.yaml
+packaged-template.yml
+
+# AWS
+.aws/
+aws-exports.js
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+venv/
+env/
+ENV/
+env.bak/
+venv.bak/
+
+# Environment variables
+.env
+.env.*
+
+# Lambda functions
+*.zip
+function.zip
+deployment-package.zip
+
+# Event-driven specific
+event-logs/
+*.event
+
+# IDE and OS
+.vscode/
+.idea/
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+tmp/
+temp/
+*.tmp


### PR DESCRIPTION
- Ignore AWS SAM and CloudFormation artifacts
- Ignore Lambda deployment packages
- Ignore Python environments and bytecode
- Ignore event logs and temporary files
- Ignore IDE and OS generated files